### PR TITLE
修复IE浏览器初始化HTML到编辑器失败的问题

### DIFF
--- a/src/configs.js
+++ b/src/configs.js
@@ -492,7 +492,7 @@ const htmlToEntity = (options, source) => (nodeName, node, createEntity) => {
 
   node.attributes && Object.keys(node.attributes).forEach((key) => {
     let attr = node.attributes[key]
-    ignoredEntityNodeAttributes.indexOf(attr.name) === -1 && (nodeAttributes[attr.name] = attr.value);
+    !!attr && ignoredEntityNodeAttributes.indexOf(attr.name) === -1 && (nodeAttributes[attr.name] = attr.value);
   })
 
   if (nodeName === 'a' && !node.querySelectorAll('img').length) {
@@ -550,7 +550,7 @@ const htmlToBlock = (options, source) => (nodeName, node) => {
 
   node.attributes && Object.keys(node.attributes).forEach((key) => {
     let attr = node.attributes[key]
-    ignoredNodeAttributes.indexOf(attr.name) === -1 && (nodeAttributes[attr.name] = attr.value);
+    !!attr && ignoredNodeAttributes.indexOf(attr.name) === -1 && (nodeAttributes[attr.name] = attr.value);
   })
 
   if (node.classList && node.classList.contains('media-wrap')) {


### PR DESCRIPTION
初始化HTML中含有超链接时，在IE浏览器中，node.attributes会获取到三个属性：href、target、null，添加null的判定，解决在IE浏览器中初始化失败的问题。