### PR TITLE
chore: passing parameters to draft-convert 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export const convertHTMLToRaw = (HTMLString, options, source) => {
   options = { ...defaultConvertOptions, ...options }
 
   try {
-    const contentState = convertFromHTML(getFromHTMLConfig(options, source))(HTMLString)
+    const contentState = convertFromHTML(getFromHTMLConfig(options, source))(HTMLString, options)
     return convertToRaw(contentState)
   } catch (error) {
     console.warn(error)
@@ -55,7 +55,7 @@ export const convertHTMLToEditorState = (HTMLString, editorDecorators, options, 
   options = { ...defaultConvertOptions, ...options }
 
   try {
-    return EditorState.createWithContent(convertFromHTML(getFromHTMLConfig(options, source))(HTMLString), editorDecorators)
+    return EditorState.createWithContent(convertFromHTML(getFromHTMLConfig(options, source))(HTMLString, options), editorDecorators)
   } catch (error) {
     console.warn(error)
     return EditorState.createEmpty(editorDecorators)


### PR DESCRIPTION
可以通过参数控制, 让convert可选的处理文本内容

在复制多段p的字符串到编辑器中时, draft-convert 默认flat是false, 导致大段文字在编辑器内被认定位一个整体, 不能独立设置单个段落样式 ,  可以通过传递options参数给draft-convert, 让这种行为是可选的.
